### PR TITLE
feat: configure setting real IP with header from other pods

### DIFF
--- a/assets/default.conf
+++ b/assets/default.conf
@@ -205,6 +205,10 @@ $(( else ))
     etag 'off';
 $(( end ))
 
+$((- if .SetRealIPFrom ))
+    set_real_ip_from $(( .SetRealIPFrom ));
+$(( end ))
+
     # (Security) Don't serve dotfiles, except .well-known/, which is needed by
     # LetsEncrypt
     location ~ /\.(?!well-known) {

--- a/build.go
+++ b/build.go
@@ -38,6 +38,8 @@ func Build(logger scribe.Emitter) packit.BuildFunc {
 					// https://github.com/paketo-buildpacks/nginx/issues/447
 					LastModifiedValue: time.Now().UTC().Format(http.TimeFormat),
 					ETag:              false,
+					// allow from Pod CIDR
+					SetRealIPFrom: "10.42.0.0/16",
 					Configuration: nginx.Configuration{
 						NGINXConfLocation: nginxConf,
 						WebServerRoot:     webRoot,

--- a/default_config_generator.go
+++ b/default_config_generator.go
@@ -25,6 +25,7 @@ type DefaultConfigGenerator struct {
 type Configuration struct {
 	LastModifiedValue string
 	ETag              bool
+	SetRealIPFrom     string
 	nginx.Configuration
 }
 


### PR DESCRIPTION
we currently don't get the real IP in the nginx logs since it does not accept it from any address by default. We can trust the pod CIDR to send the correct X-Real-IP header.