### PR TITLE
fix: disable absolute redirects

### DIFF
--- a/assets/default.conf
+++ b/assets/default.conf
@@ -193,6 +193,10 @@ $(( end ))
       # Specify files sent to client if specific file not requested (e.g.
       # GET www.example.com/). NGINX sends first existing file in the list.
       index index.html index.htm Default.htm;
+
+      # this fixes cases where nginx would redirect https://whatever/path to
+      # http://whatever/path/ when behind a TLS terminating proxy.
+      absolute_redirect off;
     }
 
 $((- if .LastModifiedValue ))


### PR DESCRIPTION
nginx will automatically redirect to paths with a trailing slash it is missing. But this lead to issues where nginx would redirect from HTTPS back to HTTP if it's running behind a proxy which already terminates TLS. As a workaround we configure nginx to do relative redirects that don't contain the scheme.