### PR TITLE
feat: enable env vars from upstream buildpack

### DIFF
--- a/build.go
+++ b/build.go
@@ -11,6 +11,7 @@ import (
 	"github.com/paketo-buildpacks/nginx"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
+	"github.com/paketo-buildpacks/packit/v2/servicebindings"
 )
 
 func Build(logger scribe.Emitter) packit.BuildFunc {
@@ -31,8 +32,15 @@ func Build(logger scribe.Emitter) packit.BuildFunc {
 		nginxConf := filepath.Join(context.WorkingDir, nginx.ConfFile)
 		if _, err := os.Stat(nginxConf); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				confGen := NewDefaultConfigGenerator(logger)
-				if err := confGen.Generate(Configuration{
+				// we re-use LoadConfiguration from the nginx buildpack to support some of the env variables.
+				cfg, err := nginx.LoadConfiguration(os.Environ(), servicebindings.NewResolver(), os.Getenv("CNB_PLATFORM_DIR"))
+				if err != nil {
+					return packit.BuildResult{}, packit.Fail.WithMessage("unable to load config: %s", err)
+				}
+				cfg.NGINXConfLocation = nginxConf
+				cfg.WebServerRoot = webRoot
+
+				if err := NewDefaultConfigGenerator(logger).Generate(Configuration{
 					// we set the last-modified header to the current time
 					// during build. This works around the issue described in:
 					// https://github.com/paketo-buildpacks/nginx/issues/447
@@ -40,10 +48,7 @@ func Build(logger scribe.Emitter) packit.BuildFunc {
 					ETag:              false,
 					// allow from Pod CIDR
 					SetRealIPFrom: "10.42.0.0/16",
-					Configuration: nginx.Configuration{
-						NGINXConfLocation: nginxConf,
-						WebServerRoot:     webRoot,
-					},
+					Configuration: cfg,
 				}); err != nil {
 					return packit.BuildResult{}, packit.Fail.WithMessage("unable to create nginx.conf: %s", err)
 				}


### PR DESCRIPTION
This enables this buildpack to make use of the same env vars as the upstream nginx buildpack by re-using the same load logic.