### PR TITLE
fix: allow node apps to also override webroot

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -36,7 +36,7 @@ func Detect(logger scribe.Emitter) packit.DetectFunc {
 			return packit.DetectResult{}, err
 		}
 		if ok {
-			webRoot = filepath.Join(nodeAppPath, "build")
+			webRoot = nodeWebRoot(nodeAppPath)
 		}
 
 		result := packit.DetectResult{
@@ -74,4 +74,14 @@ func isNodeApp(workingDir string) (bool, string, error) {
 
 		return false, "", err
 	}
+}
+
+func nodeWebRoot(nodeAppPath string) string {
+	// if explicitly specified, always use the WebRootEnv
+	if path, ok := os.LookupEnv(require.WebRootEnv); ok {
+		return path
+	}
+
+	// build is the default for react apps
+	return filepath.Join(nodeAppPath, "build")
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/BurntSushi/toml v1.3.2
-	github.com/ninech/buildpack-static-require v0.0.2
+	github.com/ninech/buildpack-static-require v0.1.0
 	github.com/onsi/gomega v1.29.0
 	github.com/paketo-buildpacks/libnodejs v0.2.0
 	github.com/paketo-buildpacks/nginx v0.15.7

--- a/go.sum
+++ b/go.sum
@@ -2470,6 +2470,10 @@ github.com/ninech/buildpack-static-require v0.0.1 h1:UXDsy3thAxdiFoI2TLDrID9puRK
 github.com/ninech/buildpack-static-require v0.0.1/go.mod h1:Xy0VP5Zk1G4JtGvi+DQpm7PeDCIzFkBoYmsb4J+K0Tc=
 github.com/ninech/buildpack-static-require v0.0.2 h1:fesQ/Gj+Tu4jvKeqvV3fmPPfUsUCZRB0tZK9+Iu26Us=
 github.com/ninech/buildpack-static-require v0.0.2/go.mod h1:Xy0VP5Zk1G4JtGvi+DQpm7PeDCIzFkBoYmsb4J+K0Tc=
+github.com/ninech/buildpack-static-require v0.0.3-0.20240423133549-6cd4ec6bcf30 h1:s+N/2wjI93rI0OOnDgv9TaWxtzSa3QW9nwTAZu0Vxj4=
+github.com/ninech/buildpack-static-require v0.0.3-0.20240423133549-6cd4ec6bcf30/go.mod h1:Xy0VP5Zk1G4JtGvi+DQpm7PeDCIzFkBoYmsb4J+K0Tc=
+github.com/ninech/buildpack-static-require v0.1.0 h1:ZIaFuvnCNLKmdXXj9JfzQWw/x11J1mxVCdOJk5Ids/o=
+github.com/ninech/buildpack-static-require v0.1.0/go.mod h1:Xy0VP5Zk1G4JtGvi+DQpm7PeDCIzFkBoYmsb4J+K0Tc=
 github.com/nishanths/exhaustive v0.2.3/go.mod h1:bhIX678Nx8inLM9PbpvK1yv6oGtoP8BfaIeMzgBNKvc=
 github.com/nishanths/predeclared v0.0.0-20190419143655-18a43bb90ffc/go.mod h1:62PewwiQTlm/7Rj+cxVYqZvDIUc+JjZq6GHAC1fsObQ=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=


### PR DESCRIPTION
for node apps the webroot was hardcoded to `build` (since it's the react default). Some other frameworks might use a different path to store the build artifacts, so we want to allow the user to override it.